### PR TITLE
fix: set sxt-testnet-data as external volume as well

### DIFF
--- a/README.md
+++ b/README.md
@@ -410,6 +410,7 @@ services:
 
 volumes:
   sxt-testnet-data:
+    external: true
   sxt-validator-key:
     external: true
   sxt-node-key:


### PR DESCRIPTION
This is necessary because now we copy the snapshot into the volume in a previous step, so the volume has already been created by the time docker compose is run.